### PR TITLE
PeopleCountをprivateに

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -6,7 +6,7 @@ public class GameManager : MonoBehaviour
 {
     public GameObject person;
     public GameObject building;
-    public int PeopleCount = 10;
+    private int PeopleCount = 10;
     // Start is called before the first frame update
     void Start()
     {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -87,7 +87,7 @@
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.test-framework": "1.1.3"
+        "com.unity.test-framework": "1.1.1"
       },
       "url": "https://packages.unity.com"
     },


### PR DESCRIPTION
publicにしていると，スクリプト側から値を変更してもUnity側のキャッシュデータを取得してしまうため，privateにしました